### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__
+*.pyc
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.10-slim
+
+# Evita preguntas de configuración
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Instalamos dependencias para Google Chrome
+RUN apt-get update && apt-get install -y \
+    wget gnupg ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libnspr4 libnss3 libxss1 libxcb-dri3-0 libu2f-udev libdrm2 libgbm1 --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+# Instalamos Google Chrome
+RUN wget -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && apt-get install -y google-chrome-stable --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+# Creamos usuario de la app
+RUN useradd -m rolando
+
+# Instala dependencias de Python
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Directorio de trabajo
+USER rolando
+WORKDIR /home/rolando/app
+
+# Carpeta para el perfil de Chrome utilizado por el script
+RUN mkdir -p /home/rolando/.config/google-chrome-bot
+
+# Copiamos el proyecto
+COPY --chown=rolando:rolando . .
+
+CMD ["python", "reserva_cancha.py"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# TenisReserva en Docker
+
+Este proyecto automatiza la reserva de canchas utilizando Selenium y Chrome. Se provee un contenedor Docker para ejecutarlo en cualquier sistema con Docker y un servidor X disponible.
+
+## Configuración
+
+1. Instala **Docker** y **docker-compose** en tu sistema Ubuntu.
+2. Copia `.env.example` a `.env` y completa los valores de `URL_AGENDAMIENTO`, `URL_AGENDAMIENTO_TEST`, `RUT` y `CELULAR`.
+
+```bash
+cp .env.example .env
+nano .env
+```
+
+3. Construye la imagen Docker:
+
+```bash
+docker compose build
+```
+
+## Ejecución
+
+1. Permite que Docker utilice tu sesión X11 (solo se necesita una vez por sesión):
+
+```bash
+xhost +local:docker
+```
+
+2. Inicia el contenedor, el cual abrirá una ventana de Google Chrome en tu máquina:
+
+```bash
+docker compose up
+```
+
+El script `reserva_cancha.py` se ejecutará automáticamente. Chrome utilizará el directorio `~/.config/google-chrome-bot` para guardar su perfil de usuario (se monta como volumen para que persista entre ejecuciones).
+
+Para detener el contenedor presiona `Ctrl+C` en la terminal.
+
+## Ejecución sin docker-compose
+
+Si prefieres correrlo directamente con `docker run`:
+
+```bash
+xhost +local:docker
+
+docker run -it --rm \
+  --env-file .env \
+  -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -v $HOME/chrome-bot:/home/rolando/.config/google-chrome-bot \
+  --network host \
+  tenis-reserva
+```
+
+Asegúrate de reemplazar `tenis-reserva` por el nombre que hayas asignado a la imagen si es distinto.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  reserva:
+    build: .
+    environment:
+      - DISPLAY=${DISPLAY}
+    env_file: .env
+    volumes:
+      - .:/home/rolando/app
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - ${HOME}/chrome-bot:/home/rolando/.config/google-chrome-bot
+    network_mode: host
+    stdin_open: true
+    tty: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+selenium>=4.0
+undetected-chromedriver
+python-dotenv


### PR DESCRIPTION
## Summary
- add Dockerfile for running Selenium and Chrome
- add docker-compose.yml to simplify running with X11
- document how to run the script in Docker
- list Python dependencies in requirements.txt
- ignore unnecessary files when building the image

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c7a3a194883299ed0517b96956a03