### PR TITLE
Add FlujoNormal to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+FlujoNormal/


### PR DESCRIPTION
## Summary
- exclude `FlujoNormal/` from the Docker build context

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6853489657808329858f96949769643b