### PR TITLE
Add container friendly config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+CHROME_USER_DATA_DIR=/tmp/chrome-profile
 URL_AGENDAMIENTO=uriverdadero
 URL_AGENDAMIENTO_TEST=uritest
 RUT=11111-1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# TenisReserva
+
+Script automatizado para reservar horas de tenis usando Selenium.
+
+## Configuración
+
+1. Copia `.env.example` a `.env` y edita los valores con tus datos reales.
+2. Ajusta `CHROME_USER_DATA_DIR` si quieres guardar el perfil de Chrome en otra ubicación. El valor por defecto es `/tmp/chrome-profile`.
+
+## Uso con Docker Compose
+
+El repositorio incluye un `docker-compose.yml` que ejecuta el script en un contenedor.
+
+```bash
+# Ejecuta una vez para construir la imagen y lanzar el contenedor
+docker compose up
+```
+
+Los valores de entorno se cargan desde el archivo `.env`.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  tenis:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - .:/app
+      - ${CHROME_USER_DATA_DIR:-/tmp/chrome-profile}:${CHROME_USER_DATA_DIR:-/tmp/chrome-profile}
+    env_file:
+      - .env
+    command: sh -c "pip install --no-cache-dir selenium undetected-chromedriver python-dotenv && python reserva_cancha.py"

--- a/reserva_cancha.py
+++ b/reserva_cancha.py
@@ -116,11 +116,17 @@ URL_AGENDAMIENTO = os.getenv("URL_AGENDAMIENTO")
 
 ES_LOCAL = not URL_AGENDAMIENTO.startswith("https://reservadehoras.lascondes.cl")
 
+user_data_dir = os.getenv("CHROME_USER_DATA_DIR", "/tmp/chrome-profile")
+os.makedirs(user_data_dir, exist_ok=True)
+
 options = uc.ChromeOptions()
 options.add_argument("--start-maximized")
+options.add_argument("--no-sandbox")
+options.add_argument("--disable-dev-shm-usage")
+options.add_argument("--headless=new")
 # options.add_argument("--profile-directory=Profile 6")
 
-driver = uc.Chrome(options=options, user_data_dir="/home/rolando/.config/google-chrome-bot")
+driver = uc.Chrome(options=options, user_data_dir=user_data_dir)
 
 try:
     encontrado = False


### PR DESCRIPTION
## Summary
- parametrize chrome profile directory through CHROME_USER_DATA_DIR
- add container-friendly chrome flags
- document configuration and Docker usage
- add minimal docker-compose setup

## Testing
- `python -m py_compile reserva_cancha.py`
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686472822eec8329963d2e7a2b250876